### PR TITLE
Add support for numeric project ids

### DIFF
--- a/gitlab-manager
+++ b/gitlab-manager
@@ -126,7 +126,10 @@ if __name__ == '__main__':
             print(e)
             exit()
     try:
-        projects = gl.projects.list(search=args.project)
+        if args.project.isdecimal():
+            projects = [gl.projects.get(args.project)]
+        else:
+            projects = gl.projects.list(search=args.project)
     except exceptions.MissingSchema:
         log.error("Error with the URL defined")
         exit()


### PR DESCRIPTION
For some unknown reason, using the project name with `projects.list(search="...")` didn't work for me.
Also, I always prefer using the numeric project ID to avoid any ambiguities in the first place (it's also faster). 

So, I've added a check to use `projects.get()` if the project argument is a decimal number.

Note: I'm only a sidecar python developer, so comments are welcome. ;-) 