### PR TITLE
Add argument to control mr state for listing

### DIFF
--- a/gitlab-manager
+++ b/gitlab-manager
@@ -19,9 +19,9 @@ class MergeRequest:
     def print_mr(self):
         return "### {}: {}\n\n{}\n\n    * by: {}\n\n    * Merge Request ID:{}\n".format(self.Label, self.Title, self.Description, self.Author, self.Id)
 
-def list_mrs(project, wip):
+def list_mrs(project, state, wip):
     print("\nHere is the list of MRs for your chosen project:\n")
-    mrs = project.mergerequests.list(state='opened', order_by='updated_at', wip=wip)
+    mrs = project.mergerequests.list(state=state, order_by='updated_at', wip=wip)
     all_mr = ""
     for mr in mrs:
         current = MergeRequest(mr)
@@ -82,6 +82,10 @@ def init_argparse():
         ls_mr = subparsers.add_parser('ls')
         ls_mr.add_argument("--wip", dest='wip', action='store', type=str,
         help='search wip or not', choices=['yes', 'no'])
+        ls_mr.add_argument("--state", dest='state', action='store', type=str,
+                           help='filter for the specified state',
+                           choices=['all', 'opened', 'closed', 'locked', 'merged'],
+                           default='opened')
         update_mr = subparsers.add_parser('update')
         update_mr.add_argument('mr_id')
         update_mr.add_argument("--label", dest='label', action='store', type=str,
@@ -142,7 +146,7 @@ if __name__ == '__main__':
     project = projects[0]
     if args.command == "mr":
         if args.action == "ls":
-            list_mrs(project, args.wip)
+            list_mrs(project, args.state, args.wip)
         if args.action == "update":
             update_mr(project, args.mr_id, args.label, args.tag)
     if args.command == "changelog":


### PR DESCRIPTION
For our workflow we need to be able to work with merged MRs. 

Therefore an optional argument is added to allow specifying the state when listing MRs

*Note, that I currently need to base all branches from the currently unmerged branch of PR #2 to work with the project on my end.*